### PR TITLE
Fixed racy clearing of interrupt signal

### DIFF
--- a/coroutine.cc
+++ b/coroutine.cc
@@ -544,15 +544,13 @@ CoroutineScheduler::ChooseRunnable(PollState *poll_state, int num_ready) {
 
 CoroutineScheduler::ChosenCoroutine
 CoroutineScheduler::GetRunnableCoroutine(PollState *poll_state, int num_ready) {
-  if (interrupt_fd_.revents != 0) {
-    // Interrupted.
-    ClearEvent(interrupt_fd_.fd);
-  }
-
   ChosenCoroutine chosen = ChooseRunnable(poll_state, num_ready);
 
   if (chosen.co != nullptr) {
     chosen.co->ClearEvent();
+  } else if (interrupt_fd_.revents != 0) {
+    // Interrupted.
+    ClearEvent(interrupt_fd_.fd);
   }
   return chosen;
 }

--- a/coroutine.cc
+++ b/coroutine.cc
@@ -544,13 +544,16 @@ CoroutineScheduler::ChooseRunnable(PollState *poll_state, int num_ready) {
 
 CoroutineScheduler::ChosenCoroutine
 CoroutineScheduler::GetRunnableCoroutine(PollState *poll_state, int num_ready) {
+  if (interrupt_fd_.revents != 0) {
+    // Interrupted.
+    ClearEvent(interrupt_fd_.fd);
+    return ChosenCoroutine();
+  }
+
   ChosenCoroutine chosen = ChooseRunnable(poll_state, num_ready);
 
   if (chosen.co != nullptr) {
     chosen.co->ClearEvent();
-  } else if (interrupt_fd_.revents != 0) {
-    // Interrupted.
-    ClearEvent(interrupt_fd_.fd);
   }
   return chosen;
 }


### PR DESCRIPTION
The last commit (https://github.com/dallison/co/commit/4c5cb00a4dfd4db95b68b76791cae25d3e62d6be) introduced a race condition between the interrupt fd and the other pollfds. If the main scheduler poll wakes up with both the interrupt fd ready and some other pollfd, it would unconditionally clear the interrupt fd, and then choose the coroutine to resume. That could result in another infinite-timeout poll to be entered with a clear interrupt fd. In other words, it would get silently ignored. Obviously, before the latest commit, the interrupt fd would just never be cleared (since interrupt_fd.revents was not updated after the poll call), so this wasn't an issue.

In my tests with the subspace server, the scheduler.Stop() function would hang forever in about 50 to 100 times out of 10,000 test runs. With this fix, that goes away. The fix can be either:

 - Clear the interrupt only if no other coroutine is to be resumed.
 - Unconditionally clear it, but ignore the coroutines in that case.

Either way works in my tests. I chose the second one, which seems more appropriate since an "interrupt" should probably have precedence over everything else.

Personally, I would have made the interrupt it's own (empty) coroutine, instead of a potentially error-prone special-case handling. But I guess this allows the precedence to be implemented.