### PR TITLE
Setcontext in coroutine only on first resume

### DIFF
--- a/coroutine.cc
+++ b/coroutine.cc
@@ -491,6 +491,7 @@ void Coroutine::Resume(int value) {
       getcontext(&exit_);
       // We will get here when the coroutines's function returns.
       if (first_resume_) {
+        first_resume_ = false;
         // This is the first time we have been resumed so set the context
         // to that set up by makecontext.  This will set the stack and invoke
         // the function.


### PR DESCRIPTION
According to the comment, this already seemed to be the intended way of how it works.

Also, running the subspace server on linux doesn't work without this line.