### PR TITLE
Initialize max_wait value to zero

### DIFF
--- a/coroutine.cc
+++ b/coroutine.cc
@@ -589,7 +589,7 @@ CoroutineScheduler::ChooseRunnable(PollState *poll_state, int num_ready) {
   // a data structure and processing it afterwards.
   Coroutine *chosen = nullptr;
   int chosen_fd;
-  uint64_t max_wait;
+  uint64_t max_wait = 0UL;
   for (size_t i = 1; i < poll_state->pollfds.size(); i++) {
     struct pollfd *fd = &poll_state->pollfds[i];
     Coroutine *co = poll_state->coroutines[i - 1];


### PR DESCRIPTION
Fix a probably mostly inconsequential compiler warning:

```
warning: 'max_wait' may be used uninitialized in this function [-Wmaybe-uninitialized]
```