### PR TITLE
Add break in switch statement

### DIFF
--- a/coroutine.cc
+++ b/coroutine.cc
@@ -317,6 +317,7 @@ void Coroutine::AddPollFds(std::vector<struct pollfd> &pollfds,
       pollfds.push_back(fd);
       covec.push_back(this);
     }
+    break;
   case State::kCoNew:
     [[fallthrough]];
   case State::kCoRunning:


### PR DESCRIPTION
The intent is just to address a compiler warning:

```
warning: this statement may fall through [-Wimplicit-fallthrough=]
```

I wasn't sure if this was intended to break or fallthrough, but it doesn't look like it changes anything either way.