### PR TITLE
Use epoll on Linux

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,10 +1,26 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+  name = "macos_arm64",
+  values = {"cpu": "darwin_arm64"},
+)
+
+config_setting(
+  name = "macos_default",
+  values = {"cpu": "darwin"},
+)
+
+config_setting(
+  name = "macos_x86_64",
+  values = {"cpu": "darwin_x86_64"},
+)
+
+
 cc_library(
     name = "co",
     srcs = [
         "coroutine.cc",
-  ],
+    ],
     hdrs = [
         "bitset.h",
         "coroutine.h",
@@ -12,9 +28,12 @@ cc_library(
     copts = [
         "-Wall",
     ],
-    deps = [
-        "@com_google_absl//absl/container:flat_hash_map",
-    ],
+    deps = select({
+        "//:macos_x86_64": [],
+        "//:macos_arm64": [],
+        "//:macos_default": [],
+        "//conditions:default": ["@com_google_absl//absl/container:flat_hash_map"],
+    }),
 )
 
 cc_binary(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,13 +4,16 @@ cc_library(
     name = "co",
     srcs = [
         "coroutine.cc",
-    ],
+  ],
     hdrs = [
         "bitset.h",
         "coroutine.h",
     ],
     copts = [
         "-Wall",
+    ],
+    deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,3 +6,11 @@ http_archive(
   strip_prefix = "googletest-5ab508a01f9eb089207ee87fd547d290da39d015",
   sha256 = "755f9a39bc7205f5a0c428e920ddad092c33c8a1b46997def3f1d4a82aded6e1",
 )
+
+http_archive(
+    name = "com_google_absl",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz"],
+    strip_prefix="abseil-cpp-20230125.3",
+    sha256 = "5366d7e7fa7ba0d915014d387b66d0d002c03236448e1ba9ef98122c13b35c36",
+)
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,12 @@ http_archive(
 )
 
 http_archive(
+  name = "bazel_skylib",
+  urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
+  sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+)
+
+http_archive(
     name = "com_google_absl",
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz"],
     strip_prefix="abseil-cpp-20230125.3",

--- a/coroutine.cc
+++ b/coroutine.cc
@@ -27,7 +27,7 @@
 #error "Unknown operating system"
 #endif
 
-[[maybe_unused]] constexpr bool kCoDebug = true;
+constexpr bool kCoDebug = false;
 
 namespace co {
 static int NewEventFd() {

--- a/coroutine.cc
+++ b/coroutine.cc
@@ -502,27 +502,7 @@ std::string Coroutine::ToString() const {
 }
 
 std::string Coroutine::MakeDefaultString() const {
-  const char *state = "unknown";
-  switch (state_) {
-  case State::kCoNew:
-    state = "new";
-    break;
-  case State::kCoDead:
-    state = "dead";
-    break;
-  case State::kCoReady:
-    state = "ready";
-    break;
-  case State::kCoRunning:
-    state = "runnning";
-    break;
-  case State::kCoWaiting:
-    state = "waiting";
-    break;
-  case State::kCoYielded:
-    state = "yielded";
-    break;
-  }
+  const char *state = StateName(state_);
   char buffer[256];
   snprintf(buffer, sizeof(buffer), "Coroutine %d: %s: state: %s: address: %p",
            id_, name_.c_str(), state, yielded_address_);

--- a/coroutine.cc
+++ b/coroutine.cc
@@ -188,6 +188,7 @@ const char *Coroutine::StateName(State state) {
   case State::kCoYielded:
     return "yielded";
   }
+  return "unknown";
 }
 
 void Coroutine::SetState(State state) {

--- a/coroutine.cc
+++ b/coroutine.cc
@@ -27,7 +27,7 @@
 #error "Unknown operating system"
 #endif
 
-[[maybe_unused]] constexpr bool kCoDebug = false;
+[[maybe_unused]] constexpr bool kCoDebug = true;
 
 namespace co {
 static int NewEventFd() {
@@ -176,6 +176,9 @@ Coroutine::~Coroutine() {
 void Coroutine::SetState(State state) {
   if (state == state_) {
     return;
+  }
+  if (kCoDebug) {
+    std::cerr << Name() << " moving from state " << int(state_) << " to " << int(state) << std::endl;
   }
 #if POLL_MODE == POLL_EPOLL
   // In epoll mode we manipulate the epoll fd set based on the state
@@ -356,7 +359,7 @@ int Coroutine::Wait(const std::vector<int> &fds, uint32_t event_mask,
 }
 
 #if POLL_MODE == POLL_EPOLL
-int Coroutine::Wait(const std::vector<WaitFd> &fds, uint64_t timeout_ns = 0) {
+int Coroutine::Wait(const std::vector<WaitFd> &fds, uint64_t timeout_ns) {
   for (auto &fd : fds) {
     wait_fds_.push_back(CoroutineFd(this, fd.fd, fd.events));
   }

--- a/coroutine.cc
+++ b/coroutine.cc
@@ -173,12 +173,30 @@ Coroutine::~Coroutine() {
 #endif
 }
 
+const char *Coroutine::StateName(State state) {
+  switch (state) {
+  case State::kCoDead:
+    return "dead";
+  case State::kCoNew:
+    return "new";
+  case State::kCoReady:
+    return "ready";
+  case State::kCoRunning:
+    return "running";
+  case State::kCoWaiting:
+    return "waiting";
+  case State::kCoYielded:
+    return "yielded";
+  }
+}
+
 void Coroutine::SetState(State state) {
   if (state == state_) {
     return;
   }
   if (kCoDebug) {
-    std::cerr << Name() << " moving from state " << int(state_) << " to " << int(state) << std::endl;
+    std::cerr << Name() << " moving from state " << StateName(state_) << " to "
+              << StateName(state) << std::endl;
   }
 #if POLL_MODE == POLL_EPOLL
   // In epoll mode we manipulate the epoll fd set based on the state

--- a/coroutine.h
+++ b/coroutine.h
@@ -265,7 +265,7 @@ private:
   CoroutineFunction function_; // Coroutine body.
   std::string name_;           // Optional name.
   int interrupt_fd_;
-  State state_;
+  State state_ = State::kCoNew;
   std::vector<char> stack_;         // Stack, allocated from malloc.
   void *yielded_address_ = nullptr; // Address at which we've yielded.
 #if CTX_MODE == CTX_SETJMP

--- a/coroutine.h
+++ b/coroutine.h
@@ -200,8 +200,10 @@ private:
   int EndOfWait(int timer_fd);
   int AddTimeout(uint64_t timeout_ns);
   State GetState() const { return state_; }
+#if POLL_MODE == POLL_POLL
   void AddPollFds(std::vector<struct pollfd> &pollfds,
                   std::vector<Coroutine *> &covec);
+#endif
   void Resume(int value);
   void TriggerEvent();
   void ClearEvent();
@@ -354,7 +356,7 @@ private:
 #if POLL_MODE == POLL_EPOLL
   int epoll_fd_ = -1;
   int interrupt_fd_ = -1;
-  size_t num_poll_events_ = 0;
+  size_t num_epoll_events_ = 0;
 #else
   PollState poll_state_;
   struct pollfd interrupt_fd_;

--- a/coroutine.h
+++ b/coroutine.h
@@ -57,6 +57,7 @@
 #include <list>
 #include <string>
 #include <vector>
+#include "absl/container/flat_hash_map.h"
 
 #include "bitset.h"
 
@@ -357,6 +358,7 @@ private:
   int epoll_fd_ = -1;
   int interrupt_fd_ = -1;
   size_t num_epoll_events_ = 0;
+  absl::flat_hash_map<int, CoroutineFd*> coroutine_fds_;
 #else
   PollState poll_state_;
   struct pollfd interrupt_fd_;

--- a/coroutine.h
+++ b/coroutine.h
@@ -241,6 +241,8 @@ private:
   template <typename T> friend class Generator;
 
   friend void __co_Invoke(Coroutine *c);
+  static const char *StateName(State state);
+
   void InvokeFunction();
   int EndOfWait(int timer_fd);
   int AddTimeout(uint64_t timeout_ns);

--- a/coroutine.h
+++ b/coroutine.h
@@ -116,7 +116,7 @@ struct CoroutineOptions {
 // of pollfds
 struct WaitFd {
   int fd;
-  uint32_t event;
+  uint32_t events;
 };
 #endif
 

--- a/coroutine.h
+++ b/coroutine.h
@@ -30,6 +30,10 @@
 // The main effect of this is when passing an interrrupt_fd to the coroutines.
 // You will need to dup(2) it before passing to more than one coroutine.  This
 // is normally what you need anyway.
+//
+// By default POLL_EPOLL is used on Linux and POLL_POLL on all other OSes.
+// If you don't want to use POLL_EPOLL on Linux, modify the setting of
+// POLL_MODE inside the defined(__linux__) below.
 #define POLL_EPOLL 1
 #define POLL_POLL 2
 
@@ -51,11 +55,12 @@
 #define CTX_MODE CTX_UCONTEXT
 #include <sys/epoll.h>
 #include <ucontext.h>
-#define POLL_MODE POLL_EPOLL
+#define POLL_MODE POLL_EPOLL                // Change this line to disable epoll
 #else
 // Portable version is setjmp/longjmp
 #define CTX_MODE CTX_SETJMP
 #include <csetjmp>
+#define POLL_MODE POLL_POLL
 #endif
 
 #include <poll.h>

--- a/cotest.cc
+++ b/cotest.cc
@@ -90,9 +90,13 @@ void TestWaitWithTimeout(Coroutine *c) {
   auto wait2_func = [wait2_end, wait3_end](Coroutine *c) {
     printf("Waiter %s waiting %d %d\n", c->Name().c_str(), wait2_end,
            wait3_end);
+#if POLL_MODE == POLL_EPOLL
+    int fd = c->Wait({wait2_end, wait3_end}, EPOLLIN, 1000000000); // Wait 1 second.
+#else
     struct pollfd fd1 = {.fd = wait2_end, .events = POLLIN};
     struct pollfd fd2 = {.fd = wait3_end, .events = POLLIN};
     int fd = c->Wait({fd1, fd2}, 1000000000); // Wait 1 second.
+#endif
     if (fd == -1) {
       printf("Waiter %s resumed due to timeout\n", c->Name().c_str());
     } else if (fd == wait3_end) {


### PR DESCRIPTION
On linux, the epoll syscall can be more efficient than poll if there are a lot of file descriptors ready.

This switches the linux implementation to use epoll.  You can turn it off by changing the `POLL_MODE` macro in coroutine.h
