### PR TITLE
Fix double-free issue with local variable vector

### DIFF
--- a/coroutine.h
+++ b/coroutine.h
@@ -456,6 +456,7 @@ private:
 #endif
   bool running_ = false;
 #if CO_POLL_MODE == CO_POLL_EPOLL
+  std::vector<struct epoll_event> events_;
   int epoll_fd_ = -1;
   int interrupt_fd_ = -1;
   size_t num_epoll_events_ = 0;


### PR DESCRIPTION
Fix double-free issue with local variable vector, affects optimized arm64 linux builds.

I'm gonna be honest, I don't really know why this fixes the issue, but it seems to.

This was discovered in optimized builds for linux-arm64 targets (not seen elsewhere), and it only seems to have appeared after an upgrade to a more recent toolchain (LLVM 14). This bug affected the subspace server during tear down. Based on other investigations that may be false positives (ASAN warns that it can't deal with user-context stuff), it might be related to removal of coroutines. That's about as much information as I have.

My hunch was that after tracking down the double-free to that local `events` vector that there might be some bad interaction between the stack switching and some compiler optimizations related the internals of that vector. So, I tried to remove it from the call stack, into the scheduler object proper, and the issue disappeared.

Hopefully, this is not just papering over a more serious stack corruption issue.