### PR TITLE
Fixed up some minor things that got clobbered in merge

### DIFF
--- a/coroutine.h
+++ b/coroutine.h
@@ -510,9 +510,8 @@ private:
   BitSet coroutine_ids_;
   uint32_t last_freed_coroutine_id_ = -1U;
   Context yield_;
-  bool running_ = false;
+  std::atomic<bool> running_ = false;
 #if CO_POLL_MODE == CO_POLL_EPOLL
-  std::vector<struct epoll_event> events_;
   int epoll_fd_ = -1;
   int interrupt_fd_ = -1;
   size_t num_epoll_events_ = 0;


### PR DESCRIPTION
Fixed up some minor things that got clobbered in merge

The running flag still needs to be atomic to make TSan happy.
The "events_" member is no longer needed. I tested the original "double-free" issue that required that fix (https://github.com/dallison/co/pull/13) and it seems to be fixed now with the new context-switching mechanism on linux-aarch64 optimized builds.